### PR TITLE
Update `tuple` dependency to 0.3.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "freude"
 version = "0.10"
 
 [dependencies.tuple]
-version = "0.2.2"
+version = "0.3.5"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
The build currently fails on my machine, because the `tuple` dependency seems to be broken at version 0.2.2.

This pull request bumps the version of the `tuple` dependency from 0.2.2 to 0.3.5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/superfluffy/rust-freude/8)
<!-- Reviewable:end -->
